### PR TITLE
parse file contents using token parser

### DIFF
--- a/src/main/java/com/lmax/angler/monitoring/network/monitor/socket/udp/UdpColumnHandler.java
+++ b/src/main/java/com/lmax/angler/monitoring/network/monitor/socket/udp/UdpColumnHandler.java
@@ -1,9 +1,9 @@
 package com.lmax.angler.monitoring.network.monitor.socket.udp;
 
-import com.lmax.angler.monitoring.network.monitor.util.TokenHandler;
 import com.lmax.angler.monitoring.network.monitor.socket.SocketIdentifier;
 import com.lmax.angler.monitoring.network.monitor.util.AsciiBytesToLongDecoder;
 import com.lmax.angler.monitoring.network.monitor.util.HexToLongDecoder;
+import com.lmax.angler.monitoring.network.monitor.util.TokenHandler;
 
 import java.nio.ByteBuffer;
 import java.util.function.Consumer;
@@ -87,9 +87,4 @@ final class UdpColumnHandler implements TokenHandler
         entry.reset();
     }
 
-    @Override
-    public void reset()
-    {
-        currentColumn = 0;
-    }
 }

--- a/src/main/java/com/lmax/angler/monitoring/network/monitor/socket/udp/UdpSocketMonitor.java
+++ b/src/main/java/com/lmax/angler/monitoring/network/monitor/socket/udp/UdpSocketMonitor.java
@@ -1,16 +1,15 @@
 package com.lmax.angler.monitoring.network.monitor.socket.udp;
 
 import com.lmax.angler.monitoring.network.monitor.socket.SocketIdentifier;
+import com.lmax.angler.monitoring.network.monitor.util.FileHandler;
 import com.lmax.angler.monitoring.network.monitor.util.FileLoader;
 import com.lmax.angler.monitoring.network.monitor.util.Parsers;
-import com.lmax.angler.monitoring.network.monitor.util.TokenHandler;
 import org.agrona.collections.Long2ObjectHashMap;
 import org.agrona.collections.LongHashSet;
 import org.agrona.collections.LongIterator;
 
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
-import java.nio.ByteBuffer;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.concurrent.atomic.AtomicReference;
@@ -28,7 +27,8 @@ public final class UdpSocketMonitor
 
     private final UdpSocketMonitoringLifecycleListener lifecycleListener;
     private final UdpColumnHandler tokenHandler = new UdpColumnHandler(this::handleEntry);
-    private final TokenHandler lineParser = Parsers.rowColumnParser(tokenHandler);
+//    private final TokenHandler lineParser = Parsers.rowColumnParser(tokenHandler);
+    private final FileHandler lineParser = Parsers.rowColumnHandler(tokenHandler);
 
     private final FileLoader fileLoader;
 
@@ -58,11 +58,7 @@ public final class UdpSocketMonitor
         this.statisticsHandler = handler;
         try
         {
-            fileLoader.load();
-            final ByteBuffer buffer = fileLoader.getBuffer();
-
-            lineParser.reset();
-            lineParser.handleToken(buffer, buffer.position(), buffer.limit());
+            fileLoader.run(lineParser);
         }
         finally
         {

--- a/src/main/java/com/lmax/angler/monitoring/network/monitor/system/snmp/SystemNetworkManagementMonitor.java
+++ b/src/main/java/com/lmax/angler/monitoring/network/monitor/system/snmp/SystemNetworkManagementMonitor.java
@@ -2,11 +2,10 @@ package com.lmax.angler.monitoring.network.monitor.system.snmp;
 
 import com.lmax.angler.monitoring.network.monitor.system.snmp.udp.SnmpUdpStatisticsColumnHandler;
 import com.lmax.angler.monitoring.network.monitor.system.snmp.udp.SnmpUdpStatisticsHandler;
+import com.lmax.angler.monitoring.network.monitor.util.FileHandler;
 import com.lmax.angler.monitoring.network.monitor.util.FileLoader;
 import com.lmax.angler.monitoring.network.monitor.util.Parsers;
-import com.lmax.angler.monitoring.network.monitor.util.TokenHandler;
 
-import java.nio.ByteBuffer;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
@@ -15,8 +14,8 @@ import java.nio.file.Paths;
  */
 public final class SystemNetworkManagementMonitor
 {
-    private final TokenHandler lineParser =
-            Parsers.rowColumnParser(new SnmpUdpStatisticsColumnHandler(this::onUpdate));
+    private final FileHandler lineParser =
+            Parsers.rowColumnHandler(new SnmpUdpStatisticsColumnHandler(this::onUpdate));
     private final FileLoader fileLoader;
     private SnmpUdpStatisticsHandler statisticsHandler;
 
@@ -42,11 +41,7 @@ public final class SystemNetworkManagementMonitor
         this.statisticsHandler = snmpUdpStatisticsHandler;
         try
         {
-            fileLoader.load();
-            final ByteBuffer buffer = fileLoader.getBuffer();
-
-            lineParser.reset();
-            lineParser.handleToken(buffer, buffer.position(), buffer.limit());
+            fileLoader.run(lineParser);
         }
         finally
         {

--- a/src/main/java/com/lmax/angler/monitoring/network/monitor/system/snmp/udp/SnmpUdpStatisticsColumnHandler.java
+++ b/src/main/java/com/lmax/angler/monitoring/network/monitor/system/snmp/udp/SnmpUdpStatisticsColumnHandler.java
@@ -78,9 +78,4 @@ public final class SnmpUdpStatisticsColumnHandler implements TokenHandler
         entry.reset();
     }
 
-    @Override
-    public void reset()
-    {
-        currentColumn = 0;
-    }
 }

--- a/src/main/java/com/lmax/angler/monitoring/network/monitor/system/softnet/SoftnetStatColumnHandler.java
+++ b/src/main/java/com/lmax/angler/monitoring/network/monitor/system/softnet/SoftnetStatColumnHandler.java
@@ -61,9 +61,4 @@ final class SoftnetStatColumnHandler implements TokenHandler
         entry.reset();
     }
 
-    @Override
-    public void reset()
-    {
-        currentColumn = 0;
-    }
 }

--- a/src/main/java/com/lmax/angler/monitoring/network/monitor/system/softnet/SoftnetStatsMonitor.java
+++ b/src/main/java/com/lmax/angler/monitoring/network/monitor/system/softnet/SoftnetStatsMonitor.java
@@ -1,14 +1,13 @@
 package com.lmax.angler.monitoring.network.monitor.system.softnet;
 
+import com.lmax.angler.monitoring.network.monitor.util.FileHandler;
 import com.lmax.angler.monitoring.network.monitor.util.FileLoader;
-import com.lmax.angler.monitoring.network.monitor.util.TokenHandler;
+import com.lmax.angler.monitoring.network.monitor.util.Parsers;
 import org.agrona.collections.Int2ObjectHashMap;
 
-import java.nio.ByteBuffer;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
-import static com.lmax.angler.monitoring.network.monitor.util.Parsers.rowColumnParser;
 import static java.lang.Runtime.getRuntime;
 
 /**
@@ -20,7 +19,7 @@ public final class SoftnetStatsMonitor
     private static final int ESTIMATED_LINE_LENGTH = 120;
 
     private final Int2ObjectHashMap<CpuSoftIrqData> cpuSoftIrqDataMap = new Int2ObjectHashMap<>();
-    private final TokenHandler lineParser = rowColumnParser(new SoftnetStatColumnHandler(this::handleEntry));
+    private final FileHandler lineParser = Parsers.rowColumnHandler(new SoftnetStatColumnHandler(this::handleEntry));
     private final FileLoader fileLoader;
 
     private SoftnetStatsHandler softnetStatsHandler;
@@ -48,12 +47,8 @@ public final class SoftnetStatsMonitor
         this.softnetStatsHandler = softnetStatsHandler;
         try
         {
-            fileLoader.load();
-            final ByteBuffer buffer = fileLoader.getBuffer();
-
             cpuId = 0;
-            lineParser.reset();
-            lineParser.handleToken(buffer, buffer.position(), buffer.limit());
+            fileLoader.run(lineParser);
         }
         finally
         {

--- a/src/main/java/com/lmax/angler/monitoring/network/monitor/util/DelimitedDataParser.java
+++ b/src/main/java/com/lmax/angler/monitoring/network/monitor/util/DelimitedDataParser.java
@@ -9,16 +9,13 @@ final class DelimitedDataParser implements TokenHandler
 {
     private final TokenHandler tokenHandler;
     private final byte delimiter;
-    private final boolean skipConsecutiveDelimiters;
 
     DelimitedDataParser(
             final TokenHandler tokenHandler,
-            final byte delimiter,
-            final boolean skipConsecutiveDelimiters)
+            final byte delimiter)
     {
         this.tokenHandler = tokenHandler;
         this.delimiter = delimiter;
-        this.skipConsecutiveDelimiters = skipConsecutiveDelimiters;
     }
 
     /**
@@ -53,7 +50,6 @@ final class DelimitedDataParser implements TokenHandler
             currentPosition += 1;
 
             while(
-                    skipConsecutiveDelimiters &&
                     currentPosition < endPosition &&
                     src.get(currentPosition) == delimiter)
             {
@@ -64,15 +60,6 @@ final class DelimitedDataParser implements TokenHandler
         }
 
         tokenHandler.complete();
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void reset()
-    {
-        tokenHandler.reset();
     }
 
     /**

--- a/src/main/java/com/lmax/angler/monitoring/network/monitor/util/FileHandler.java
+++ b/src/main/java/com/lmax/angler/monitoring/network/monitor/util/FileHandler.java
@@ -4,7 +4,7 @@ import java.nio.ByteBuffer;
 
 public interface FileHandler
 {
-    void handleData(ByteBuffer src, int startPosition, int endPosition);
+    void handleData(final ByteBuffer src, final int startPosition, final int endPosition);
 
     void noFurtherData();
 }

--- a/src/main/java/com/lmax/angler/monitoring/network/monitor/util/FileLoader.java
+++ b/src/main/java/com/lmax/angler/monitoring/network/monitor/util/FileLoader.java
@@ -4,7 +4,6 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 
@@ -24,40 +23,10 @@ public final class FileLoader
     }
 
     /**
-     * Opens a channel to the specified path if it does not already exist.
-     * Allocates a larger ByteBuffer if file size &gt; current buffer size.
-     * Reads file data into ByteBuffer.
-     */
-    public void load()
-    {
-        try
-        {
-            if (fileChannel == null)
-            {
-                fileChannel = FileChannel.open(path, StandardOpenOption.READ);
-            }
-            final long fileSize = Files.size(path);
-
-            if (fileSize > buffer.capacity())
-            {
-                buffer = ByteBuffer.allocateDirect((int) Math.max(buffer.capacity() * 2, fileSize));
-            }
-
-            buffer.clear();
-            fileChannel.read(buffer, 0);
-            buffer.flip();
-        }
-        catch(final IOException e)
-        {
-            throw new UncheckedIOException(e);
-        }
-    }
-
-    /**
-     * Visit the data within the specified path, passing it to
+     * Visit the data contained within the specified path, passing it to
      * the supplied file handler as it is seen.
      */
-    public void run(FileHandler fileHandler)
+    public void run(final FileHandler fileHandler)
     {
         try
         {
@@ -85,10 +54,5 @@ public final class FileLoader
         {
             throw new UncheckedIOException(e);
         }
-    }
-
-    public ByteBuffer getBuffer()
-    {
-        return buffer;
     }
 }

--- a/src/main/java/com/lmax/angler/monitoring/network/monitor/util/Parsers.java
+++ b/src/main/java/com/lmax/angler/monitoring/network/monitor/util/Parsers.java
@@ -4,17 +4,18 @@ public final class Parsers
 {
     private static final byte COLUMN_DELIMITER = (byte) ' ';
     private static final byte ROW_DELIMITER = (byte) '\n';
+    private static final int MAXIMUM_LINE_LENGTH = 1024;
 
-    public static TokenHandler rowColumnParser(
-            TokenHandler tokenHandler)
+    public static FileHandler rowColumnHandler(
+            final TokenHandler tokenHandler)
     {
-        return new DelimitedDataParser(
+        return new TokenParser(
                 new DelimitedDataParser(
                         tokenHandler,
-                        COLUMN_DELIMITER,
-                        true),
+                        COLUMN_DELIMITER
+                ),
                 ROW_DELIMITER,
-                true);
+                MAXIMUM_LINE_LENGTH);
     }
 
     private Parsers() {}

--- a/src/main/java/com/lmax/angler/monitoring/network/monitor/util/TokenHandler.java
+++ b/src/main/java/com/lmax/angler/monitoring/network/monitor/util/TokenHandler.java
@@ -19,9 +19,4 @@ public interface TokenHandler
      * Current token set is complete.
      */
     void complete();
-
-    /**
-     * Reset state in preparation for handling a new data set.
-     */
-    void reset();
 }

--- a/src/main/java/com/lmax/angler/monitoring/network/monitor/util/TokenParser.java
+++ b/src/main/java/com/lmax/angler/monitoring/network/monitor/util/TokenParser.java
@@ -1,0 +1,116 @@
+package com.lmax.angler.monitoring.network.monitor.util;
+
+import java.nio.BufferOverflowException;
+import java.nio.ByteBuffer;
+
+final class TokenParser implements FileHandler
+{
+    private final TokenHandler tokenHandler;
+    private final byte delimiter;
+    private final ByteBuffer buffer;
+
+    TokenParser(
+            final TokenHandler tokenHandler,
+            final byte delimiter,
+            int maximumTokenSize)
+    {
+        this.tokenHandler = tokenHandler;
+        this.delimiter = delimiter;
+        this.buffer = ByteBuffer.allocateDirect(maximumTokenSize);
+    }
+
+    public void handleData(final ByteBuffer src, final int startPosition, final int endPosition)
+    {
+        // Strategy to minimise copying
+        //    1.) if the buffer has content, add to it until we see a delimiter, then dispatch that token
+        //    2.) peruse the remaining data in source for tokens
+        //    3.) park any leftover bytes in the internal buffer
+        int currentPosition = startPosition;
+        if (buffer.position() > 0)
+        {
+            while (currentPosition < endPosition && src.get(currentPosition) != delimiter)
+            {
+                putOne(src.get(currentPosition));
+                currentPosition++;
+            }
+
+            final boolean tokenFound = currentPosition != endPosition;
+            if (tokenFound)
+            {
+                putOne(src.get(currentPosition));
+                currentPosition++;
+
+                dispatchFromInternalBuffer();
+            }
+        }
+
+        while (currentPosition < endPosition)
+        {
+            int tokenStart = currentPosition;
+            while (currentPosition < endPosition && src.get(currentPosition) != delimiter)
+            {
+                currentPosition++;
+            }
+
+            final boolean tokenFound = currentPosition != endPosition;
+            if (tokenFound)
+            {
+                currentPosition++;
+
+                dispatchToTokenHandler(src, tokenStart, currentPosition);
+            }
+            else
+            {
+                copyToInternalBuffer(src, tokenStart, currentPosition);
+            }
+        }
+    }
+
+    private void putOne(final byte b)
+    {
+        try
+        {
+            buffer.put(b);
+        }
+        catch (BufferOverflowException boe)
+        {
+            throw new RuntimeException(
+                    "Encountered input without delimiter larger than buffer size (" + buffer.capacity() + ")",
+                    boe);
+        }
+    }
+
+    @Override
+    public void noFurtherData()
+    {
+        if (buffer.position() > 0)
+        {
+            buffer.flip();
+            tokenHandler.handleToken(buffer, 0, buffer.remaining());
+            buffer.clear();
+        }
+    }
+
+    private void dispatchToTokenHandler(final ByteBuffer bb, final int startPosition, final int endPosition)
+    {
+        if (endPosition - startPosition > 1)
+        {
+            tokenHandler.handleToken(bb, startPosition, endPosition - 1);
+        }
+    }
+
+    private void dispatchFromInternalBuffer()
+    {
+        buffer.flip();
+        dispatchToTokenHandler(buffer, 0, buffer.remaining());
+        buffer.clear();
+    }
+
+    private void copyToInternalBuffer(final ByteBuffer bb, final int startPosition, final int endPosition)
+    {
+        for (int i = startPosition; i < endPosition; i++)
+        {
+            putOne(bb.get(i));
+        }
+    }
+}

--- a/src/test/java/com/lmax/angler/monitoring/network/monitor/system/softnet/SoftnetStatsMonitorTest.java
+++ b/src/test/java/com/lmax/angler/monitoring/network/monitor/system/softnet/SoftnetStatsMonitorTest.java
@@ -71,10 +71,10 @@ public class SoftnetStatsMonitorTest
                                     final long dropped,
                                     final long timeSqueeze)
     {
-        assertThat(softnetStatEntry.getCpuId(), is(cpuId));
-        assertThat(softnetStatEntry.getProcessed(), is(total));
-        assertThat(softnetStatEntry.getDropped(), is(dropped));
-        assertThat(softnetStatEntry.getSqueezed(), is(timeSqueeze));
+        assertThat("cpuid", softnetStatEntry.getCpuId(), is(cpuId));
+        assertThat("processed", softnetStatEntry.getProcessed(), is(total));
+        assertThat("dropped", softnetStatEntry.getDropped(), is(dropped));
+        assertThat("squeezed", softnetStatEntry.getSqueezed(), is(timeSqueeze));
     }
 
     private static class RecordingSoftnetStatsHandler implements SoftnetStatsHandler

--- a/src/test/java/com/lmax/angler/monitoring/network/monitor/util/DelimitedDataParserTest.java
+++ b/src/test/java/com/lmax/angler/monitoring/network/monitor/util/DelimitedDataParserTest.java
@@ -15,7 +15,7 @@ public final class DelimitedDataParserTest
 {
     private final List<String> collectedTokens = new ArrayList<>();
     private final TokenCollector collector = new TokenCollector(collectedTokens);
-    private final DelimitedDataParser parser = new DelimitedDataParser(collector, (byte) '\n', true);
+    private final DelimitedDataParser parser = new DelimitedDataParser(collector, (byte) '\n');
 
     @Test
     public void shouldFindZeroTokensWhenDataIsEmpty() throws Exception
@@ -86,8 +86,8 @@ public final class DelimitedDataParserTest
     public void shouldNest() throws Exception
     {
         final ByteBuffer src = bufferForData("\n\n 1st    line \n 2nd   line \n\n  3rd    line");
-        final DelimitedDataParser inner = new DelimitedDataParser(collector, (byte)'\n', true);
-        final DelimitedDataParser outer = new DelimitedDataParser(inner, (byte)' ', true);
+        final DelimitedDataParser inner = new DelimitedDataParser(collector, (byte)'\n');
+        final DelimitedDataParser outer = new DelimitedDataParser(inner, (byte)' ');
         outer.handleToken(src, src.position(), src.limit());
 
         assertThat(collectedTokens.size(), is(6));
@@ -97,39 +97,5 @@ public final class DelimitedDataParserTest
     private static ByteBuffer bufferForData(final String data)
     {
         return ByteBuffer.wrap(data.getBytes(StandardCharsets.UTF_8));
-    }
-
-    private static final class TokenCollector implements TokenHandler
-    {
-        private final List<String> collectedTokens;
-
-        private TokenCollector(final List<String> collectedTokens)
-        {
-            this.collectedTokens = collectedTokens;
-        }
-
-        @Override
-        public void handleToken(final ByteBuffer src, final int startPosition, final int endPosition)
-        {
-            final byte[] tmp = new byte[endPosition - startPosition];
-            final int bufferPosition = src.position();
-            final int bufferLimit = src.limit();
-            src.position(startPosition).limit(endPosition);
-            src.get(tmp, 0, endPosition - startPosition);
-            src.position(bufferPosition).limit(bufferLimit);
-            collectedTokens.add(new String(tmp));
-        }
-
-        @Override
-        public void complete()
-        {
-
-        }
-
-        @Override
-        public void reset()
-        {
-
-        }
     }
 }

--- a/src/test/java/com/lmax/angler/monitoring/network/monitor/util/TokenCollector.java
+++ b/src/test/java/com/lmax/angler/monitoring/network/monitor/util/TokenCollector.java
@@ -1,0 +1,33 @@
+package com.lmax.angler.monitoring.network.monitor.util;
+
+import java.nio.ByteBuffer;
+import java.util.List;
+
+final class TokenCollector implements TokenHandler
+{
+    private final List<String> collectedTokens;
+
+    TokenCollector(final List<String> collectedTokens)
+    {
+        this.collectedTokens = collectedTokens;
+    }
+
+    @Override
+    public void handleToken(final ByteBuffer src, final int startPosition, final int endPosition)
+    {
+        final byte[] tmp = new byte[endPosition - startPosition];
+        final int bufferPosition = src.position();
+        final int bufferLimit = src.limit();
+        src.position(startPosition).limit(endPosition);
+        src.get(tmp, 0, endPosition - startPosition);
+        src.position(bufferPosition).limit(bufferLimit);
+        collectedTokens.add(new String(tmp));
+    }
+
+    @Override
+    public void complete()
+    {
+
+    }
+
+}

--- a/src/test/java/com/lmax/angler/monitoring/network/monitor/util/TokenParserTest.java
+++ b/src/test/java/com/lmax/angler/monitoring/network/monitor/util/TokenParserTest.java
@@ -1,0 +1,97 @@
+package com.lmax.angler.monitoring.network.monitor.util;
+
+import org.junit.Test;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class TokenParserTest
+{
+    private final List<String> collectedTokens = new ArrayList<>();
+    private final TokenParser parser = new TokenParser(new TokenCollector(collectedTokens), (byte) '\n', 64);
+
+    @Test
+    public void emptyInputYieldsNoTokens()
+    {
+        handleData("");
+        parser.noFurtherData();
+
+        assertThat(collectedTokens.size(), is(0));
+    }
+
+    @Test
+    public void inputEntirelyOfDelimitersYieldsNoTokens()
+    {
+        handleData("\n\n\n\n\n\n");
+        handleData("\n\n\n");
+        parser.noFurtherData();
+
+        assertThat(collectedTokens.size(), is(0));
+    }
+
+    @Test
+    public void finalTokenIsDeliveredOnNotificationOfNoFurtherData()
+    {
+        handleData("foo\nbar");
+
+        assertThat(collectedTokens, is(singletonList("foo")));
+
+        parser.noFurtherData();
+
+        assertThat(collectedTokens, is(asList("foo", "bar")));
+    }
+
+    @Test
+    public void parsesNonEmptyTokensFromChunkedInput()
+    {
+        handleData("hello\nthis is some input with");
+        handleData(" line breaks\n\n\n\nsplit across several ");
+        handleData("invocations");
+        handleData("\n\n\n\n");
+        handleData("\nmoo\n\n\ni\n\nsay");
+        parser.noFurtherData();
+
+        assertThat(
+                collectedTokens,
+                is(asList(
+                        "hello",
+                        "this is some input with line breaks",
+                        "split across several invocations",
+                        "moo",
+                        "i",
+                        "say")));
+    }
+
+    @Test
+    public void throwHelpfulErrorWhenBufferOverflows()
+    {
+        try
+        {
+            final byte[] chars = new byte[65];
+            Arrays.fill(chars, (byte) 'a');
+            handleData(new String(chars, StandardCharsets.US_ASCII));
+        }
+        catch (RuntimeException re)
+        {
+            assertThat(re.getMessage(), is("Encountered input without delimiter larger than buffer size (64)"));
+        }
+    }
+
+    private void handleData(String pieceOne)
+    {
+        parser.handleData(bufferForData(pieceOne), 0, pieceOne.length());
+    }
+
+    private static ByteBuffer bufferForData(final String data)
+    {
+        return ByteBuffer.wrap(data.getBytes(StandardCharsets.UTF_8));
+    }
+}


### PR DESCRIPTION
TokenParser is very similar to DelimitedDataParser, but it has to be able to cope with input that crosses 'handleData' invocations. This means we can avoid having growable buffers, so long as we can guess how long a line is allowed to be for a given input (which we can do for everything, right now, I think).

I've deliberately left the implementation in a fully inlined state - there is some repetition in there that could be cleverly factored out. That 'cleverly' word put me off though.

There probably aren't enough test cases for TokenParser, and I probably missed some finals somewhere (but I added some others elsewhere).

I removed some extraneous detail from DelimitedDataParser in addition.
